### PR TITLE
Update Fancycamera Dependency

### DIFF
--- a/android/capacitor-video-recorder/build.gradle
+++ b/android/capacitor-video-recorder/build.gradle
@@ -43,7 +43,9 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'ionic-team:capacitor-android:1+'
-    implementation 'co.fitcom:fancycamera:0.4.2'
+    implementation ('co.fitcom:fancycamera:0.4.2'){
+        exclude group: "com.android.support"
+    }
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'

--- a/android/capacitor-video-recorder/build.gradle
+++ b/android/capacitor-video-recorder/build.gradle
@@ -43,7 +43,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'ionic-team:capacitor-android:1+'
-    implementation 'co.fitcom:fancycamera:0.4.0'
+    implementation 'co.fitcom:fancycamera:0.4.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'


### PR DESCRIPTION
Updates to 0.4.2 to fix `cameraStarted` method declaration missing.