### PR TITLE
Update the currentFrameConfig when switchToPreviewFrame changes configs

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -154,6 +154,7 @@ export class VideoRecorderWeb extends WebPlugin implements VideoRecorderPlugin {
 			}
 			let config = this.previewFrameConfigs.filter(config => config.id === options.id);
 			if (config.length > 0) {
+				this.currentFrameConfig = config[0];
 				this._updateCameraView(config[0]);
 			}
 			else {


### PR DESCRIPTION
I was running into a problem when toggling between two different preview frame configs using the `VideoRecorder.switchToPreviewFrame({ id: 'someId' })` function.

The problem is, while `switchToPreviewFrame` does update the configuration correctly, it does not update it's internal pointer to the `currentFrameConfig`. Thus, if I want to know what the currentFrameConfig is after switching, it can no longer be relied upon to be accurate.

I'm sure there are probably some build steps and/or spec changes that are necessary to ship with this PR but wanted to propose the logical change first.