### PR TITLE
essential: Fixes Preview Frames on Android

### DIFF
--- a/android/@teamhive/capacitor-video-recorder/src/main/java/com/github/sbannigan/capacitor/VideoRecorder.java
+++ b/android/@teamhive/capacitor-video-recorder/src/main/java/com/github/sbannigan/capacitor/VideoRecorder.java
@@ -127,6 +127,9 @@ public class VideoRecorder extends Plugin {
                 }
                 startTimer();
                 updateCameraView(currentFrameConfig);
+                for (FrameConfig f : previewFrameConfigs.values()) {
+                    updateCameraView(f);
+                }
             }
 
             public void onCameraCloseUI() {


### PR DESCRIPTION
closes #27  by dereferencing the stored preview frame configurations and actually applying them when necessary. Without this code there is no "stackPosition":"front" possible. Imo this is **essential** functionality.