### PR TITLE
chore(fancy-camera): update version to 1.2.2

### DIFF
--- a/android/@teamhive/capacitor-video-recorder/build.gradle
+++ b/android/@teamhive/capacitor-video-recorder/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation project(':capacitor-android')
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support:design:28.0.0'
-    implementation ('co.fitcom:fancycamera:0.6.8'){
+    implementation ('co.fitcom:fancycamera:1.2.2'){
         exclude group: "com.android.support"
     }
     testImplementation "junit:junit:$junitVersion"

--- a/android/@teamhive/capacitor-video-recorder/src/main/java/com/github/sbannigan/capacitor/VideoRecorder.java
+++ b/android/@teamhive/capacitor-video-recorder/src/main/java/com/github/sbannigan/capacitor/VideoRecorder.java
@@ -120,6 +120,7 @@ public class VideoRecorder extends Plugin {
         previewFrameConfigs = new HashMap<>();
 
         fancyCamera = new FancyCamera(this.getContext());
+        fancyCamera.setDisableHEVC(true);
         fancyCamera.setListener(new CameraEventListenerUI() {
             public void onCameraOpenUI() {
                 if (getCall() != null) {


### PR DESCRIPTION
Was having some trouble with android, the video preview was streched. Updating fancycamera to 1.2.2 solved the problem.

This fancycamera version create videos with HEVC/H.265 coded. I disable it so we can mantain compatibility with HTML5 video tags.

regards